### PR TITLE
Prepare services for symfony 4.0

### DIFF
--- a/src/Fieg/StatisticoBundle/Command/BucketsCommand.php
+++ b/src/Fieg/StatisticoBundle/Command/BucketsCommand.php
@@ -3,12 +3,17 @@
 namespace Fieg\StatisticoBundle\Command;
 
 use Fieg\Statistico\Reader;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class BucketsCommand extends ContainerAwareCommand
+class BucketsCommand extends Command
 {
+    /**
+     * @var Reader
+     */
+    private $reader;
+
     protected function configure()
     {
         $this
@@ -16,12 +21,18 @@ class BucketsCommand extends ContainerAwareCommand
        ;
     }
 
+    /**
+     * @param Reader $reader
+     */
+    public function __construct(Reader $reader)
+    {
+        $this->reader = $reader;
+        parent::__construct();
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var Reader $reader */
-        $reader = $this->getContainer()->get('statistico.reader');
-
-        $buckets = $reader->getBuckets();
+        $buckets = $this->reader->getBuckets();
 
         foreach ($buckets as $bucket) {
             $output->writeln(sprintf('<info>%s</info>', $bucket));

--- a/src/Fieg/StatisticoBundle/Command/GraphCommand.php
+++ b/src/Fieg/StatisticoBundle/Command/GraphCommand.php
@@ -3,12 +3,26 @@
 namespace Fieg\StatisticoBundle\Command;
 
 use Fieg\Statistico\Reader;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class GraphCommand extends ContainerAwareCommand
+class GraphCommand extends Command
 {
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    /**
+     * @param Reader $reader
+     */
+    public function __construct(Reader $reader)
+    {
+        $this->reader = $reader;
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -20,13 +34,10 @@ class GraphCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         while (true) {
-            /** @var Reader $reader */
-            $reader = $this->getContainer()->get('statistico.reader');
-
             $from = new \DateTime('-1 minute');
             $to = new \DateTime();
 
-            $buckets = $reader->getBuckets();
+            $buckets = $this->reader->getBuckets();
             $bucketArgument = $input->getArgument('bucket');
 
             $buckets = array_filter(
@@ -46,7 +57,7 @@ class GraphCommand extends ContainerAwareCommand
             $out = [];
 
             foreach ($buckets as $bucket) {
-                $counts = $reader->queryCounts($bucket, 'seconds', $from, $to);
+                $counts = $this->reader->queryCounts($bucket, 'seconds', $from, $to);
                 $rpm = array_sum($counts);
 
                 $minX = $from->getTimestamp();

--- a/src/Fieg/StatisticoBundle/Resources/config/services.yml
+++ b/src/Fieg/StatisticoBundle/Resources/config/services.yml
@@ -13,3 +13,17 @@ services:
     class: Fieg\Statistico\Reader
     arguments:
       - '@statistico.driver.redis'
+
+  statistico.command.buckets:
+    class: Fieg\StatisticoBundle\Command\BucketsCommand
+    arguments:
+      - '@statistico.reader'
+    tags:
+      - { name: 'console.command' }
+
+  statistico.command.graph:
+    class: Fieg\StatisticoBundle\Command\GraphCommand
+    arguments:
+      - '@statistico.reader'
+    tags:
+      - { name: 'console.command' }


### PR DESCRIPTION
Since sf 3.3 the auto-registration of services and commands is deprecated and from 4.0 it will be removed.

I've updated the services to be configurated and also injected dependencies so they are no longer containeraware.